### PR TITLE
Create 5. DHCP Different Pools for Known & Unknown Clients.md

### DIFF
--- a/5. DHCP Different Pools for Known & Unknown Clients.md
+++ b/5. DHCP Different Pools for Known & Unknown Clients.md
@@ -1,0 +1,92 @@
+
+# **🔄 DHCP Configuration: Different Pools for Known & Unknown Clients**  
+
+You can configure your **DHCP server to assign different IP address pools** based on whether the client is known (listed in the configuration) or unknown.  
+
+---
+
+## **1️⃣ Edit the DHCP Configuration File**  
+
+📝 Open the DHCP configuration file for editing:  
+```bash
+vim /etc/dhcp/dhcpd.conf
+```
+
+---
+
+## **2️⃣ Example Configuration for Differentiating Known and Unknown Clients**  
+
+To allow only **specific clients** in one IP range and **assign another range to unknown clients**, use separate `pool` directives.  
+
+### **Example: Assign Separate Pools**  
+
+```bash
+authoritative;
+
+# Specify network address and subnet mask
+subnet 192.168.1.0 netmask 255.255.255.0 {
+
+    # Specify default gateway
+    option routers 192.168.1.1;
+
+    # DNS servers for name resolution
+    option domain-name-servers 8.8.8.8, 8.8.4.4;
+
+    # Specify broadcast address
+    option broadcast-address 192.168.1.255;
+
+    # Default lease time (in seconds)
+    default-lease-time 600;
+
+    # Maximum lease time (in seconds)
+    max-lease-time 7200;
+
+    # Pool for known clients
+    pool {
+        range 192.168.1.150 192.168.1.200;
+        allow known-clients;
+    }
+
+    # Pool for unknown clients
+    pool {
+        range 192.168.1.201 192.168.1.250;
+        allow unknown-clients;
+    }
+}
+
+# Define known clients
+host win11-1 {
+    hardware ethernet 08:00:27:d6:86:94;
+    fixed-address 192.168.1.151;
+}
+
+host win11-2 {
+    hardware ethernet 08:00:27:fd:a8:e3;
+    fixed-address 192.168.1.152;
+}
+```
+
+---
+
+## **3️⃣ Restart DHCP Service**  
+
+After modifying the configuration file, restart the DHCP service for changes to take effect:  
+
+```bash
+systemctl restart dhcpd
+```
+
+---
+
+## **🛠️ Explanation**  
+
+✅ `allow known-clients;` → **Assigns IPs from the specified pool to recognized devices** (those with defined MAC addresses).  
+✅ `allow unknown-clients;` → **Assigns IPs from another pool to unrecognized devices** (any device not listed as a host).  
+✅ `host` directive → **Defines specific MAC addresses as known clients** and optionally assigns a fixed IP.  
+
+### **⚠️ Why Use Separate Pools?**  
+🔹 **Enhanced network security** by controlling DHCP assignments.  
+🔹 **Prioritization of trusted devices** with a different IP range.  
+🔹 **Prevention of IP conflicts** by assigning fixed IPs to known devices.  
+
+---


### PR DESCRIPTION

# **🔄 DHCP Configuration: Different Pools for Known & Unknown Clients**  

You can configure your **DHCP server to assign different IP address pools** based on whether the client is known (listed in the configuration) or unknown.  

---

## **1️⃣ Edit the DHCP Configuration File**  

📝 Open the DHCP configuration file for editing:  
```bash
vim /etc/dhcp/dhcpd.conf
```

---

## **2️⃣ Example Configuration for Differentiating Known and Unknown Clients**  

To allow only **specific clients** in one IP range and **assign another range to unknown clients**, use separate `pool` directives.  

### **Example: Assign Separate Pools**  

```bash
authoritative;

# Specify network address and subnet mask
subnet 192.168.1.0 netmask 255.255.255.0 {

    # Specify default gateway
    option routers 192.168.1.1;

    # DNS servers for name resolution
    option domain-name-servers 8.8.8.8, 8.8.4.4;

    # Specify broadcast address
    option broadcast-address 192.168.1.255;

    # Default lease time (in seconds)
    default-lease-time 600;

    # Maximum lease time (in seconds)
    max-lease-time 7200;

    # Pool for known clients
    pool {
        range 192.168.1.150 192.168.1.200;
        allow known-clients;
    }

    # Pool for unknown clients
    pool {
        range 192.168.1.201 192.168.1.250;
        allow unknown-clients;
    }
}

# Define known clients
host win11-1 {
    hardware ethernet 08:00:27:d6:86:94;
    fixed-address 192.168.1.151;
}

host win11-2 {
    hardware ethernet 08:00:27:fd:a8:e3;
    fixed-address 192.168.1.152;
}
```

---

## **3️⃣ Restart DHCP Service**  

After modifying the configuration file, restart the DHCP service for changes to take effect:  

```bash
systemctl restart dhcpd
```

---

## **🛠️ Explanation**  

✅ `allow known-clients;` → **Assigns IPs from the specified pool to recognized devices** (those with defined MAC addresses).  
✅ `allow unknown-clients;` → **Assigns IPs from another pool to unrecognized devices** (any device not listed as a host).  
✅ `host` directive → **Defines specific MAC addresses as known clients** and optionally assigns a fixed IP.  

### **⚠️ Why Use Separate Pools?**  
🔹 **Enhanced network security** by controlling DHCP assignments.  
🔹 **Prioritization of trusted devices** with a different IP range.  
🔹 **Prevention of IP conflicts** by assigning fixed IPs to known devices.  

---
