### PR TITLE
Binding with IP Address in Apache.md

### DIFF
--- a/Binding with IP Address in Apache.md
+++ b/Binding with IP Address in Apache.md
@@ -1,0 +1,393 @@
+Apache can bind to specific IP addresses and ports, allowing you to host multiple websites on the same server using Virtual Hosts. This guide covers how to configure Apache to bind to specific IP addresses and set up virtual hosts for multiple websites.
+
+## 1. Types of Apache Binding
+Apache can be configured to bind to:
+
+- A specific IP Address
+- All available IP Addresses
+- Multiple Ports
+
+---
+
+## 1.1 Binding to All Available IP Addresses
+By default, Apache listens on all available IP addresses:
+
+```bash
+Listen 80
+```
+
+### Configure Main File
+Search Listen Area:
+```bash
+#Listen 12.34.56.78:80
+Listen 80
+```
+Apache will listen on port *80* on all available network interfaces.
+
+### Restart Apache After Modifying the Configuration
+```bash
+systemctl restart httpd.service
+```
+
+#### Example output from *netstat*:
+```bash
+netstat -nltup | grep httpd
+```
+
+#### Output:
+```bash
+tcp      0         0.0.0.0:80      0.0.0.0:*      LISTEN      1234/httpd
+```
+*0.0.0.0* indicates that Apache is listening on all available IP addresses.
+
+---
+
+## 1.2 Binding to a Specific IP Address
+To bind Apache to a specific IP address:
+
+### 1. Open the Apache Configuration File:
+```bash
+nano /etc/httpd/conf/httpd.conf
+```
+
+### 2. Modify the *Listen* directive:
+```bash
+Listen 127.0.0.1:80
+```
+
+### Configure Main File
+Search Listen Area:
+```bash
+#Listen 12.34.56.78:80
+Listen 127.0.0.1:80
+```
+This restricts Apache to only listen on *127.0.0.1* (localhost).
+
+### Restart Apache After Modifying the Configuration
+```bash
+systemctl restart httpd.service
+```
+
+#### Example output from *netstat*:
+```bash
+netstat -nltup | grep httpd
+```
+
+#### Output:
+```bash
+tcp      0      0  127.0.0.1:80      0.0.0.0:*      LISTEN      1234/httpd
+```
+
+---
+
+## 1.3 Binding to a LAN IP Address
+To bind Apache to a LAN IP address *(192.168.112.145)*:
+
+### 1. Open the Apache Configuration File:
+```bash
+nano /etc/httpd/conf/httpd.conf
+```
+
+### 2. Modify the *Listen* directive:
+```bash
+Listen 192.168.112.145:80
+```
+
+### Configure Main File
+Search Listen Area:
+```bash
+#Listen 12.34.56.78:80
+Listen 192.168.112.145:80
+```
+This allows Apache to listen only on the LAN IP *192.168.112.145*.
+
+### Restart Apache After Modifying the Configuration
+```bash
+systemctl restart httpd.service
+```
+
+#### Example Output from *netstat*:
+```bash
+netstat -nltup | grep httpd
+```
+
+#### Output:
+```bash
+tcp      0      0  192.168.112.145:80      0.0.0.0:*      LISTEN      1234/httpd
+```
+
+---
+
+## 1.4 Binding to Multiple Ports
+Apache can also listen on multiple ports simultaneously.
+
+### 1. Open the Apache Configuration File:
+```bash
+nano /etc/httpd/conf/httpd.conf
+```
+
+### 2. Add Ports *81* and *82*:
+```bash
+firewall-cmd --permanent --add-port=81/tcp
+firewall-cmd --permanent --add-port=82/tcp
+firewall-cmd --reload
+```
+
+### 3. Add Multiple *Listen* Directives:
+```bash
+Listen 80
+Listen 81
+Listen 82
+```
+
+### Configure Main File
+Search Listen Area:
+```bash
+#Listen 12.34.56.78:80
+#Listen 80
+Listen 80
+Listen 81
+Listen 82
+```
+Apache will listen on ports *80*, *81*, and *82*.
+
+### Restart Apache After Modifying the Configuration
+```bash
+systemctl restart httpd.service
+```
+
+#### Example Output from *netstat*:
+```bash
+netstat -nltup | grep httpd
+```
+
+#### Output:
+```bash
+tcp      0      0  0.0.0.0:80      0.0.0.0:*      LISTEN      1234/httpd
+tcp      0      0  0.0.0.0:81      0.0.0.0:*      LISTEN      1234/httpd
+tcp      0      0  0.0.0.0:82      0.0.0.0:*      LISTEN      1234/httpd
+```
+
+---
+
+## 2. Restart Apache Service
+After modifying the configuration, restart Apache:
+```bash
+systemctl restart httpd.service
+```
+
+### Check if the Configuration is Valid:
+```bash
+httpd -t
+```
+
+---
+
+## 3. Verify Binding
+Use *netstat* to confirm that Apache is listening on the configured ports:
+```bash
+netstat -nltup | grep httpd
+```
+
+---
+
+## Summary
+
+| Type of Binding       | Example Configuration            | Use Case                                   |
+|-----------------------|---------------------------------|-------------------------------------------|
+| Bind to All IPs       | Listen 80                       | Default Setting, Accessible from all interfaces |
+| Bind to Specific IP   | Listen 127.0.0.1:80             | Restrict to localhost or specific IP |
+| Bind to LAN IP        | Listen 192.168.112.145:80       | Restrict to LAN Interface |
+| Bind to Multiple Ports| Listen 80, Listen 81, Listen 82 | Allow Listening on Multiple Ports |
+
+
+
+---
+
+
+# Binding with IP Address in Apache
+
+## 1. Create Website Directories
+
+1. Navigate to the document root:
+   ```bash
+   cd /var/www/html/
+   ```
+
+2. Create directories for each website:
+   ```bash
+   mkdir site1 site2 site3
+   ```
+
+3. Set permissions:
+   ```bash
+   chown -Rv apache:apache site1 site2 site3
+   ```
+4. Download and Extract Template Files
+   
+   Download template:
+   ```bash
+   wget "https://www.free-css.com/assets/files/free-css-templates/download/page296/oxer.zip"
+   ```
+   
+   Unzip the template:
+   ```bash
+   unzip templatemo_571_hexashop.zip
+   ```
+   
+   Remove the ZIP file:
+   ```bash
+   rm -rf templatemo_571_hexashop.zip
+   ```
+   
+   Move extracted folder:
+   ```bash
+   mv -v templatemo_571_hexashop /var/www/html/site1/
+   ```
+
+5. Test site on Web Browser.
+   ```bash
+   192.168.112.145/site1/
+   ```
+
+## 2. Modify Apache Configuration
+
+Open the main Apache configuration file:
+```bash
+nano /etc/httpd/conf/httpd.conf
+```
+Ensure the following line is present to allow virtual hosts *(should be at the last line)*:
+```apache
+IncludeOptional conf.d/*.conf
+```
+
+Add multiple Virtual Host entries:
+```apache
+<VirtualHost 192.168.112.145:80>
+    DocumentRoot /var/www/html/site1/
+    DirectoryIndex index.html
+</VirtualHost>
+
+<VirtualHost 192.168.112.146:80>
+    DocumentRoot /var/www/html/site2/
+    DirectoryIndex index.html
+</VirtualHost>
+
+<VirtualHost 192.168.112.147:80>
+    DocumentRoot /var/www/html/site3/
+    DirectoryIndex index.html
+</VirtualHost>
+```
+
+Apply the changes by restarting the Apache service:
+```bash
+systemctl restart httpd.service
+```
+
+## 3. Create Virtual Host Files
+
+Create individual virtual host configuration files under `/etc/httpd/conf.d/`.
+
+### 3.1. Single IP Binding
+
+Bind Apache to a specific IP address (`192.168.112.145`) for a single site:
+```bash
+nano /etc/httpd/conf.d/site1.conf
+```
+Example:
+```apache
+<VirtualHost 192.168.112.145:80>
+    DocumentRoot /var/www/html/site1/
+    DirectoryIndex index.html
+</VirtualHost>
+```
+
+Apply the changes by restarting the Apache service:
+```bash
+systemctl restart httpd.service
+```
+
+### 3.2. Multiple IP Bindings
+
+#### site2.conf
+```bash
+nano /etc/httpd/conf.d/site2.conf
+```
+Example:
+```apache
+<VirtualHost 192.168.112.146:80>
+    DocumentRoot /var/www/html/site2/
+    DirectoryIndex index.html
+</VirtualHost>
+```
+
+Apply the changes by restarting the Apache service:
+```bash
+systemctl restart httpd.service
+```
+
+#### site3.conf
+```bash
+nano /etc/httpd/conf.d/site3.conf
+```
+Example:
+```apache
+<VirtualHost 192.168.112.147:80>
+    DocumentRoot /var/www/html/site3/
+    DirectoryIndex index.html
+</VirtualHost>
+```
+
+Apply the changes by restarting the Apache service:
+```bash
+systemctl restart httpd.service
+```
+
+### 3.3. Binding to All IP Addresses
+
+If you want Apache to listen on all available IP addresses:
+```bash
+nano /etc/httpd/conf.d/site1.conf
+```
+Example:
+```apache
+<VirtualHost *:80>
+    DocumentRoot /var/www/html/site1/
+    DirectoryIndex index.html
+</VirtualHost>
+```
+
+## 4. Validate Configuration
+
+Check if the Apache configuration is valid:
+```bash
+httpd -t
+```
+Example output:
+```
+Syntax OK
+```
+
+## 5. Restart Apache
+
+Apply the changes by restarting the Apache service:
+```bash
+systemctl restart httpd.service
+```
+
+## 6. Test the Configuration
+
+Use `netstat` to confirm Apache is listening on the correct ports:
+```bash
+netstat -nltup | grep httpd
+```
+
+## Summary
+
+| Type of Binding       | Example Configuration              | Use Case                                  |
+|-----------------------|----------------------------------|-------------------------------------------|
+| Bind to All IPs       | `<VirtualHost *:80>`             | Use when you want Apache to listen on all interfaces |
+| Bind to Specific IP   | `<VirtualHost 192.168.112.145:80>`  | Use to host multiple sites on different IPs |
+| Bind to Multiple IPs  | Multiple `<VirtualHost>` blocks | Use to configure several virtual hosts |
+
+This setup ensures proper virtual hosting using Apache with specific IP bindings.


### PR DESCRIPTION
Apache can bind to specific IP addresses and ports, allowing you to host multiple websites on the same server using Virtual Hosts. This guide covers how to configure Apache to bind to specific IP addresses and set up virtual hosts for multiple websites.

## 1. Types of Apache Binding
Apache can be configured to bind to:

- A specific IP Address
- All available IP Addresses
- Multiple Ports

---

## 1.1 Binding to All Available IP Addresses
By default, Apache listens on all available IP addresses:

```bash
Listen 80
```

### Configure Main File
Search Listen Area:
```bash
#Listen 12.34.56.78:80
Listen 80
```
Apache will listen on port *80* on all available network interfaces.

### Restart Apache After Modifying the Configuration
```bash
systemctl restart httpd.service
```

#### Example output from *netstat*:
```bash
netstat -nltup | grep httpd
```

#### Output:
```bash
tcp      0         0.0.0.0:80      0.0.0.0:*      LISTEN      1234/httpd
```
*0.0.0.0* indicates that Apache is listening on all available IP addresses.

---

## 1.2 Binding to a Specific IP Address
To bind Apache to a specific IP address:

### 1. Open the Apache Configuration File:
```bash
nano /etc/httpd/conf/httpd.conf
```

### 2. Modify the *Listen* directive:
```bash
Listen 127.0.0.1:80
```

### Configure Main File
Search Listen Area:
```bash
#Listen 12.34.56.78:80
Listen 127.0.0.1:80
```
This restricts Apache to only listen on *127.0.0.1* (localhost).

### Restart Apache After Modifying the Configuration
```bash
systemctl restart httpd.service
```

#### Example output from *netstat*:
```bash
netstat -nltup | grep httpd
```

#### Output:
```bash
tcp      0      0  127.0.0.1:80      0.0.0.0:*      LISTEN      1234/httpd
```

---

## 1.3 Binding to a LAN IP Address
To bind Apache to a LAN IP address *(192.168.112.145)*:

### 1. Open the Apache Configuration File:
```bash
nano /etc/httpd/conf/httpd.conf
```

### 2. Modify the *Listen* directive:
```bash
Listen 192.168.112.145:80
```

### Configure Main File
Search Listen Area:
```bash
#Listen 12.34.56.78:80
Listen 192.168.112.145:80
```
This allows Apache to listen only on the LAN IP *192.168.112.145*.

### Restart Apache After Modifying the Configuration
```bash
systemctl restart httpd.service
```

#### Example Output from *netstat*:
```bash
netstat -nltup | grep httpd
```

#### Output:
```bash
tcp      0      0  192.168.112.145:80      0.0.0.0:*      LISTEN      1234/httpd
```

---

## 1.4 Binding to Multiple Ports
Apache can also listen on multiple ports simultaneously.

### 1. Open the Apache Configuration File:
```bash
nano /etc/httpd/conf/httpd.conf
```

### 2. Add Ports *81* and *82*:
```bash
firewall-cmd --permanent --add-port=81/tcp
firewall-cmd --permanent --add-port=82/tcp
firewall-cmd --reload
```

### 3. Add Multiple *Listen* Directives:
```bash
Listen 80
Listen 81
Listen 82
```

### Configure Main File
Search Listen Area:
```bash
#Listen 12.34.56.78:80
#Listen 80
Listen 80
Listen 81
Listen 82
```
Apache will listen on ports *80*, *81*, and *82*.

### Restart Apache After Modifying the Configuration
```bash
systemctl restart httpd.service
```

#### Example Output from *netstat*:
```bash
netstat -nltup | grep httpd
```

#### Output:
```bash
tcp      0      0  0.0.0.0:80      0.0.0.0:*      LISTEN      1234/httpd
tcp      0      0  0.0.0.0:81      0.0.0.0:*      LISTEN      1234/httpd
tcp      0      0  0.0.0.0:82      0.0.0.0:*      LISTEN      1234/httpd
```

---

## 2. Restart Apache Service
After modifying the configuration, restart Apache:
```bash
systemctl restart httpd.service
```

### Check if the Configuration is Valid:
```bash
httpd -t
```

---

## 3. Verify Binding
Use *netstat* to confirm that Apache is listening on the configured ports:
```bash
netstat -nltup | grep httpd
```

---

## Summary

| Type of Binding       | Example Configuration            | Use Case                                   |
|-----------------------|---------------------------------|-------------------------------------------|
| Bind to All IPs       | Listen 80                       | Default Setting, Accessible from all interfaces |
| Bind to Specific IP   | Listen 127.0.0.1:80             | Restrict to localhost or specific IP |
| Bind to LAN IP        | Listen 192.168.112.145:80       | Restrict to LAN Interface |
| Bind to Multiple Ports| Listen 80, Listen 81, Listen 82 | Allow Listening on Multiple Ports |



---


# Binding with IP Address in Apache

## 1. Create Website Directories

1. Navigate to the document root:
   ```bash
   cd /var/www/html/
   ```

2. Create directories for each website:
   ```bash
   mkdir site1 site2 site3
   ```

3. Set permissions:
   ```bash
   chown -Rv apache:apache site1 site2 site3
   ```
4. Download and Extract Template Files
   
   Download template:
   ```bash
   wget "https://www.free-css.com/assets/files/free-css-templates/download/page296/oxer.zip"
   ```
   
   Unzip the template:
   ```bash
   unzip templatemo_571_hexashop.zip
   ```
   
   Remove the ZIP file:
   ```bash
   rm -rf templatemo_571_hexashop.zip
   ```
   
   Move extracted folder:
   ```bash
   mv -v templatemo_571_hexashop /var/www/html/site1/
   ```

5. Test site on Web Browser.
   ```bash
   192.168.112.145/site1/
   ```

## 2. Modify Apache Configuration

Open the main Apache configuration file:
```bash
nano /etc/httpd/conf/httpd.conf
```
Ensure the following line is present to allow virtual hosts *(should be at the last line)*:
```apache
IncludeOptional conf.d/*.conf
```

Add multiple Virtual Host entries:
```apache
<VirtualHost 192.168.112.145:80>
    DocumentRoot /var/www/html/site1/
    DirectoryIndex index.html
</VirtualHost>

<VirtualHost 192.168.112.146:80>
    DocumentRoot /var/www/html/site2/
    DirectoryIndex index.html
</VirtualHost>

<VirtualHost 192.168.112.147:80>
    DocumentRoot /var/www/html/site3/
    DirectoryIndex index.html
</VirtualHost>
```

Apply the changes by restarting the Apache service:
```bash
systemctl restart httpd.service
```

## 3. Create Virtual Host Files

Create individual virtual host configuration files under `/etc/httpd/conf.d/`.

### 3.1. Single IP Binding

Bind Apache to a specific IP address (`192.168.112.145`) for a single site:
```bash
nano /etc/httpd/conf.d/site1.conf
```
Example:
```apache
<VirtualHost 192.168.112.145:80>
    DocumentRoot /var/www/html/site1/
    DirectoryIndex index.html
</VirtualHost>
```

Apply the changes by restarting the Apache service:
```bash
systemctl restart httpd.service
```

### 3.2. Multiple IP Bindings

#### site2.conf
```bash
nano /etc/httpd/conf.d/site2.conf
```
Example:
```apache
<VirtualHost 192.168.112.146:80>
    DocumentRoot /var/www/html/site2/
    DirectoryIndex index.html
</VirtualHost>
```

Apply the changes by restarting the Apache service:
```bash
systemctl restart httpd.service
```

#### site3.conf
```bash
nano /etc/httpd/conf.d/site3.conf
```
Example:
```apache
<VirtualHost 192.168.112.147:80>
    DocumentRoot /var/www/html/site3/
    DirectoryIndex index.html
</VirtualHost>
```

Apply the changes by restarting the Apache service:
```bash
systemctl restart httpd.service
```

### 3.3. Binding to All IP Addresses

If you want Apache to listen on all available IP addresses:
```bash
nano /etc/httpd/conf.d/site1.conf
```
Example:
```apache
<VirtualHost *:80>
    DocumentRoot /var/www/html/site1/
    DirectoryIndex index.html
</VirtualHost>
```

## 4. Validate Configuration

Check if the Apache configuration is valid:
```bash
httpd -t
```
Example output:
```
Syntax OK
```

## 5. Restart Apache

Apply the changes by restarting the Apache service:
```bash
systemctl restart httpd.service
```

## 6. Test the Configuration

Use `netstat` to confirm Apache is listening on the correct ports:
```bash
netstat -nltup | grep httpd
```

## Summary

| Type of Binding       | Example Configuration              | Use Case                                  |
|-----------------------|----------------------------------|-------------------------------------------|
| Bind to All IPs       | `<VirtualHost *:80>`             | Use when you want Apache to listen on all interfaces |
| Bind to Specific IP   | `<VirtualHost 192.168.112.145:80>`  | Use to host multiple sites on different IPs |
| Bind to Multiple IPs  | Multiple `<VirtualHost>` blocks | Use to configure several virtual hosts |

This setup ensures proper virtual hosting using Apache with specific IP bindings.
