### PR TITLE
Binding with Domain Names in Apache.md

### DIFF
--- a/4. Binding with Domain Names in Apache.md
+++ b/4. Binding with Domain Names in Apache.md
@@ -1,0 +1,184 @@
+# Binding with Domain Names in Apache
+
+Apache can bind to specific domain names using the `ServerName` and `ServerAlias` directives in Virtual Hosts. This allows you to host multiple websites on the same IP address, each accessible by a unique domain name.
+
+## 1. Configure Hostnames (DNS or /etc/hosts)
+To simulate DNS resolution, define the domain names in the `/etc/hosts` file.
+
+Edit `/etc/hosts`:
+```bash
+vim /etc/hosts
+```
+Add the following entries:
+```bash
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+192.168.112.145 ns1 ns1.nikhil.local nikhil.local www.nikhil.local patidar.local www.patidar.local ai.local www.ai.local
+```
+This will resolve the domain names to the local IP `(192.168.112.145)`.
+
+## 2. Test DNS Resolution
+Use `dig` to confirm that the domain names resolve to the correct IP:
+```bash
+dig www.nikhil.local +short
+```
+Example output:
+```bash
+192.168.112.145
+```
+Use `dig` to confirm that the domain names resolve to the correct IP:
+
+```bash
+dig www.patidar.local +short
+```
+Example output:
+```bash
+192.168.112.146
+```
+If a different IP appears, update the entry:
+
+```
+nano /var/named/forward.patidar.local
+```
+
+Old IP:
+```bash
+patidar.local.  IN  A  192.168.112.146
+```
+New IP:
+```bash
+patidar.local.  IN  A  192.168.112.145
+```
+Restart the named service:
+```bash
+systemctl restart named
+```
+Check again:
+```bash
+dig www.patidar.local +short
+```
+Example output:
+```bash
+192.168.112.145
+```
+
+## 3. Create Apache Virtual Host Files
+Define virtual hosts for each domain. Apache will route incoming requests based on `ServerName` and `ServerAlias`.
+
+### 3.1. Main Virtual Host (Default)
+Create a default virtual host file:
+```bash
+nano /etc/httpd/conf/httpd.conf
+```
+Delete all old files:
+```bash
+cd /etc/httpd/conf.d/
+rm -rf site*
+```
+
+### 3.2. Virtual Host for `nikhil.local`
+Create a virtual host file:
+```bash
+nano /etc/httpd/conf.d/nikhil.conf
+```
+Configuration:
+```apache
+<VirtualHost 192.168.112.145:80>
+   ServerName nikhil.local
+   ServerAlias www.nikhil.local
+   DocumentRoot /var/www/html/site1/
+   DirectoryIndex index.html
+</VirtualHost>
+```
+
+### 3.3. Virtual Host for `patidar.local`
+Create a virtual host file:
+```bash
+nano /etc/httpd/conf.d/patidar.conf
+```
+Configuration:
+```apache
+<VirtualHost 192.168.112.145:80>
+   ServerName patidar.local
+   ServerAlias www.patidar.local
+   DocumentRoot /var/www/html/site2/
+   DirectoryIndex index.html
+</VirtualHost>
+```
+
+### 3.4. Virtual Host for `ai.local`
+Create a virtual host file:
+```bash
+nano /etc/httpd/conf.d/ai.conf
+```
+Configuration:
+```apache
+<VirtualHost 192.168.112.145:80>
+   ServerName ai.local
+   ServerAlias www.ai.local
+   DocumentRoot /var/www/html/site3/
+   DirectoryIndex index.html
+</VirtualHost>
+```
+Restart Apache:
+```bash
+systemctl restart httpd
+```
+
+## 4. Binding Domains with Different Ports
+You can also bind the same domains to different ports using `Listen`.
+
+### Bind `nikhil.local` on Port 8080
+Edit Apache config:
+```bash
+nano /etc/httpd/conf.d/nikhil-8080.conf
+```
+Configuration:
+```apache
+<VirtualHost 192.168.112.145:8080>
+   ServerName nikhil.local
+   ServerAlias www.nikhil.local
+   DocumentRoot /var/www/html/site4/
+   DirectoryIndex index.html
+</VirtualHost>
+```
+
+## 5. Validate Configuration
+Check if the Apache configuration is valid:
+```bash
+httpd -t
+```
+Example output:
+```bash
+Syntax OK
+```
+
+## 6. Restart Apache
+Apply the changes:
+```bash
+systemctl restart httpd.service
+```
+
+## 7. Test the Configuration
+Use `netstat` to confirm Apache is listening on the correct ports:
+```bash
+netstat -nltup | grep httpd
+```
+
+## 8. Test in Browser
+You should be able to access the sites by their domain names:
+
+| Domain | Port | Expected Output |
+|--------|------|----------------|
+| `http://nikhil.local` | 80 | site1 homepage |
+| `http://www.nikhil.local` | 80 | site1 homepage |
+| `http://patidar.local` | 80 | site2 homepage |
+| `http://www.patidar.local` | 80 | site2 homepage |
+| `http://ai.local` | 80 | site3 homepage |
+| `http://www.ai.local` | 80 | site3 homepage |
+| `http://nikhil.local:8080` | 8080 | site4 homepage |
+| `http://patidar.local:8080` | 8080 | Demo homepage |
+| `http://ai.local:8081` | 8081 | Demo homepage |
+
+**Apache virtual host binding with domain names is now complete!**
+


### PR DESCRIPTION
# Binding with Domain Names in Apache

Apache can bind to specific domain names using the `ServerName` and `ServerAlias` directives in Virtual Hosts. This allows you to host multiple websites on the same IP address, each accessible by a unique domain name.

## 1. Configure Hostnames (DNS or /etc/hosts)
To simulate DNS resolution, define the domain names in the `/etc/hosts` file.

Edit `/etc/hosts`:
```bash
vim /etc/hosts
```
Add the following entries:
```bash
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
192.168.112.145 ns1 ns1.nikhil.local nikhil.local www.nikhil.local patidar.local www.patidar.local ai.local www.ai.local
```
This will resolve the domain names to the local IP `(192.168.112.145)`.

## 2. Test DNS Resolution
Use `dig` to confirm that the domain names resolve to the correct IP:
```bash
dig www.nikhil.local +short
```
Example output:
```bash
192.168.112.145
```
Use `dig` to confirm that the domain names resolve to the correct IP:

```bash
dig www.patidar.local +short
```
Example output:
```bash
192.168.112.146
```
If a different IP appears, update the entry:

```
nano /var/named/forward.patidar.local
```

Old IP:
```bash
patidar.local.  IN  A  192.168.112.146
```
New IP:
```bash
patidar.local.  IN  A  192.168.112.145
```
Restart the named service:
```bash
systemctl restart named
```
Check again:
```bash
dig www.patidar.local +short
```
Example output:
```bash
192.168.112.145
```

## 3. Create Apache Virtual Host Files
Define virtual hosts for each domain. Apache will route incoming requests based on `ServerName` and `ServerAlias`.

### 3.1. Main Virtual Host (Default)
Create a default virtual host file:
```bash
nano /etc/httpd/conf/httpd.conf
```
Delete all old files:
```bash
cd /etc/httpd/conf.d/
rm -rf site*
```

### 3.2. Virtual Host for `nikhil.local`
Create a virtual host file:
```bash
nano /etc/httpd/conf.d/nikhil.conf
```
Configuration:
```apache
<VirtualHost 192.168.112.145:80>
   ServerName nikhil.local
   ServerAlias www.nikhil.local
   DocumentRoot /var/www/html/site1/
   DirectoryIndex index.html
</VirtualHost>
```

### 3.3. Virtual Host for `patidar.local`
Create a virtual host file:
```bash
nano /etc/httpd/conf.d/patidar.conf
```
Configuration:
```apache
<VirtualHost 192.168.112.145:80>
   ServerName patidar.local
   ServerAlias www.patidar.local
   DocumentRoot /var/www/html/site2/
   DirectoryIndex index.html
</VirtualHost>
```

### 3.4. Virtual Host for `ai.local`
Create a virtual host file:
```bash
nano /etc/httpd/conf.d/ai.conf
```
Configuration:
```apache
<VirtualHost 192.168.112.145:80>
   ServerName ai.local
   ServerAlias www.ai.local
   DocumentRoot /var/www/html/site3/
   DirectoryIndex index.html
</VirtualHost>
```
Restart Apache:
```bash
systemctl restart httpd
```

## 4. Binding Domains with Different Ports
You can also bind the same domains to different ports using `Listen`.

### Bind `nikhil.local` on Port 8080
Edit Apache config:
```bash
nano /etc/httpd/conf.d/nikhil-8080.conf
```
Configuration:
```apache
<VirtualHost 192.168.112.145:8080>
   ServerName nikhil.local
   ServerAlias www.nikhil.local
   DocumentRoot /var/www/html/site4/
   DirectoryIndex index.html
</VirtualHost>
```

## 5. Validate Configuration
Check if the Apache configuration is valid:
```bash
httpd -t
```
Example output:
```bash
Syntax OK
```

## 6. Restart Apache
Apply the changes:
```bash
systemctl restart httpd.service
```

## 7. Test the Configuration
Use `netstat` to confirm Apache is listening on the correct ports:
```bash
netstat -nltup | grep httpd
```

## 8. Test in Browser
You should be able to access the sites by their domain names:

| Domain | Port | Expected Output |
|--------|------|----------------|
| `http://nikhil.local` | 80 | site1 homepage |
| `http://www.nikhil.local` | 80 | site1 homepage |
| `http://patidar.local` | 80 | site2 homepage |
| `http://www.patidar.local` | 80 | site2 homepage |
| `http://ai.local` | 80 | site3 homepage |
| `http://www.ai.local` | 80 | site3 homepage |
| `http://nikhil.local:8080` | 8080 | site4 homepage |
| `http://patidar.local:8080` | 8080 | Demo homepage |
| `http://ai.local:8081` | 8081 | Demo homepage |

**Apache virtual host binding with domain names is now complete!**

