### PR TITLE
Create 2. DHCP Exclusion IP.md

### DIFF
--- a/DHCP Server /2. DHCP Exclusion IP.md
+++ b/DHCP Server /2. DHCP Exclusion IP.md
@@ -1,0 +1,97 @@
+
+# **🛑 Configuring DHCP Exclusion Range**  
+
+You can define an **exclusion range** in the DHCP configuration file to prevent certain IP addresses within the subnet from being assigned to clients. This is useful for reserving IP addresses for **static assignments** or **specific devices**.  
+
+---
+
+## **1️⃣ Edit DHCP Configuration File**  
+
+📝 Open the DHCP configuration file for editing:  
+```bash
+vim /etc/dhcp/dhcpd.conf
+```
+
+---
+
+## **2️⃣ Example Configurations for Exclusion Range**  
+
+You can **exclude specific IP addresses** within a subnet by defining multiple **range statements**.
+
+### **Example 1: Exclude `192.168.1.51` to `192.168.1.70`**  
+This setup ensures that **IP addresses within this range are not assigned** to DHCP clients.
+
+```bash
+subnet 192.168.1.0 netmask 255.255.255.0 {
+    # Define IP range (Excludes 192.168.1.51 - 192.168.1.70)
+    range 192.168.1.71 192.168.1.250;
+
+    # Default gateway
+    option routers 192.168.1.1;
+
+    # DNS servers
+    option domain-name-servers 8.8.8.8, 8.8.4.4;
+
+    # Broadcast address
+    option broadcast-address 192.168.1.255;
+
+    # Lease time settings
+    default-lease-time 600;
+    max-lease-time 7200;
+}
+```
+
+---
+
+### **Example 2: Exclude `192.168.1.51` to `192.168.1.60` and `192.168.1.211` to `192.168.1.230`**  
+
+To **exclude multiple IP ranges**, define separate `range` statements:
+
+```bash
+authoritative;
+
+subnet 192.168.1.0 netmask 255.255.255.0 {
+    # Define IP range (Excludes 192.168.1.51 - 192.168.1.60 and 192.168.1.211 - 192.168.1.230)
+    range 192.168.1.50 192.168.1.50;
+    range 192.168.1.61 192.168.1.210;
+    range 192.168.1.231 192.168.1.250;
+
+    # Default gateway
+    option routers 192.168.1.1;
+
+    # DNS servers
+    option domain-name-servers 8.8.8.8, 8.8.4.4;
+
+    # Broadcast address
+    option broadcast-address 192.168.1.255;
+
+    # Lease time settings
+    default-lease-time 600;
+    max-lease-time 7200;
+}
+```
+
+---
+
+## **3️⃣ Restart DHCP Service**  
+
+🔄 After making changes to the configuration file, restart the DHCP service:  
+```bash
+systemctl restart dhcpd
+```
+
+---
+
+## **🔍 Explanation**  
+
+✅ **Excluded IP Addresses**: Any addresses between the defined range statements will be **excluded** from DHCP assignments.  
+
+- **Example 1**: IPs **`192.168.1.51` to `192.168.1.70`** are **excluded**.  
+- **Example 2**: IPs **`192.168.1.51` to `192.168.1.60`** and **`192.168.1.211` to `192.168.1.230`** are **excluded**.  
+
+✅ **Why Use Exclusion Ranges?**  
+- Prevents DHCP from assigning reserved/static IPs.  
+- Avoids conflicts with devices that require fixed IPs (e.g., printers, servers).  
+- Ensures better control over IP allocation.  
+
+---


### PR DESCRIPTION

# **🛑 Configuring DHCP Exclusion Range**  

You can define an **exclusion range** in the DHCP configuration file to prevent certain IP addresses within the subnet from being assigned to clients. This is useful for reserving IP addresses for **static assignments** or **specific devices**.  

---

## **1️⃣ Edit DHCP Configuration File**  

📝 Open the DHCP configuration file for editing:  
```bash
vim /etc/dhcp/dhcpd.conf
```

---

## **2️⃣ Example Configurations for Exclusion Range**  

You can **exclude specific IP addresses** within a subnet by defining multiple **range statements**.

### **Example 1: Exclude `192.168.1.51` to `192.168.1.70`**  
This setup ensures that **IP addresses within this range are not assigned** to DHCP clients.

```bash
subnet 192.168.1.0 netmask 255.255.255.0 {
    # Define IP range (Excludes 192.168.1.51 - 192.168.1.70)
    range 192.168.1.71 192.168.1.250;

    # Default gateway
    option routers 192.168.1.1;

    # DNS servers
    option domain-name-servers 8.8.8.8, 8.8.4.4;

    # Broadcast address
    option broadcast-address 192.168.1.255;

    # Lease time settings
    default-lease-time 600;
    max-lease-time 7200;
}
```

---

### **Example 2: Exclude `192.168.1.51` to `192.168.1.60` and `192.168.1.211` to `192.168.1.230`**  

To **exclude multiple IP ranges**, define separate `range` statements:

```bash
authoritative;

subnet 192.168.1.0 netmask 255.255.255.0 {
    # Define IP range (Excludes 192.168.1.51 - 192.168.1.60 and 192.168.1.211 - 192.168.1.230)
    range 192.168.1.50 192.168.1.50;
    range 192.168.1.61 192.168.1.210;
    range 192.168.1.231 192.168.1.250;

    # Default gateway
    option routers 192.168.1.1;

    # DNS servers
    option domain-name-servers 8.8.8.8, 8.8.4.4;

    # Broadcast address
    option broadcast-address 192.168.1.255;

    # Lease time settings
    default-lease-time 600;
    max-lease-time 7200;
}
```

---

## **3️⃣ Restart DHCP Service**  

🔄 After making changes to the configuration file, restart the DHCP service:  
```bash
systemctl restart dhcpd
```

---

## **🔍 Explanation**  

✅ **Excluded IP Addresses**: Any addresses between the defined range statements will be **excluded** from DHCP assignments.  

- **Example 1**: IPs **`192.168.1.51` to `192.168.1.70`** are **excluded**.  
- **Example 2**: IPs **`192.168.1.51` to `192.168.1.60`** and **`192.168.1.211` to `192.168.1.230`** are **excluded**.  

✅ **Why Use Exclusion Ranges?**  
- Prevents DHCP from assigning reserved/static IPs.  
- Avoids conflicts with devices that require fixed IPs (e.g., printers, servers).  
- Ensures better control over IP allocation.  

---
